### PR TITLE
Fix build by marking CountdownTimer as client component

### DIFF
--- a/components/CountdownTimer.tsx
+++ b/components/CountdownTimer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
 interface CountdownProps {


### PR DESCRIPTION
## Summary
- fix Next.js build by adding "use client" directive to CountdownTimer

## Testing
- `npm run build` *(fails: next not found)*