### PR TITLE
Refine dark-mode style and add framer-motion

### DIFF
--- a/app/conference/page.tsx
+++ b/app/conference/page.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
+import { motion } from "framer-motion";
 
 export default function ConferencePage() {
   return (
     <div className="flex flex-col min-h-screen font-sans text-gray-900 dark:text-gray-100 bg-background">
       {/* Hero Section */}
-      <section className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-950 via-gray-900 to-gray-800"
+      >
         <h1 className="text-4xl sm:text-6xl font-bold tracking-tight">PROJECT LONGSHOT 2025 Conference</h1>
         <p className="text-lg sm:text-xl max-w-2xl">Shaping global policy and science for safe AI</p>
         <p className="text-md font-mono">Mid-2025 (exact dates soon)</p>
@@ -12,10 +18,16 @@ export default function ConferencePage() {
           <input type="email" placeholder="Email address" className="flex-1 px-4 py-2 rounded border border-gray-300 dark:border-gray-700 bg-transparent" />
           <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Express Interest</button>
         </form>
-      </section>
+      </motion.section>
 
       {/* Conference Overview */}
-      <section className="py-16 px-6 text-center flex flex-col items-center gap-4">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.2 }}
+        className="py-16 px-6 text-center flex flex-col items-center gap-4"
+      >
         <h2 className="text-3xl font-semibold">Conference Overview</h2>
         <p className="max-w-3xl">A brief description of the event will go here. Themes include:</p>
         <ul className="list-disc list-inside text-left max-w-xl">
@@ -23,13 +35,19 @@ export default function ConferencePage() {
           <li>Global policy and governance</li>
           <li>Cutting-edge research insights</li>
         </ul>
-      </section>
+      </motion.section>
 
       {/* Speakers Section */}
-      <section className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+        className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4"
+      >
         <h2 className="text-3xl font-semibold">Speakers</h2>
         <p>Announcing Speakers Soon...</p>
-      </section>
+      </motion.section>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,19 +1,21 @@
 @import "tailwindcss";
 
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #ffffff;
+    --foreground: #171717;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), var(--font-plex), sans-serif;
+  @apply antialiased;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
+import { Inter, IBM_Plex_Sans } from "next/font/google";
 import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
+const plex = IBM_Plex_Sans({ subsets: ["latin"], variable: "--font-plex", display: "swap" });
 
 export const metadata: Metadata = {
   title: "PROJECT LONGSHOT",
@@ -12,8 +16,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased">
+    <html lang="en" className={`${inter.variable} ${plex.variable} dark`}>
+      <body>
         <header className="py-4 px-6 bg-gray-800 text-gray-200">
           <nav className="flex gap-4">
             <a href="/" className="hover:underline">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,30 @@
 import CountdownTimer from "../components/CountdownTimer";
 import Link from "next/link";
+import { motion } from "framer-motion";
 
 export default function Home() {
   return (
     <div className="flex flex-col min-h-screen font-sans text-gray-900 dark:text-gray-100 bg-background">
       {/* Hero Section */}
-      <section className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-950 via-gray-900 to-gray-800"
+      >
         <h1 className="text-4xl sm:text-6xl font-bold tracking-tight">Aligning AI. Securing the Future.</h1>
         <p className="text-lg sm:text-xl max-w-2xl">Join world-leading experts and policymakers at the forefront of AI alignment.</p>
         <Link href="#about" className="mt-6 inline-block bg-blue-600 hover:bg-blue-700 text-white rounded-full px-6 py-3">Learn More About PROJECT LONGSHOT</Link>
-      </section>
+      </motion.section>
 
       {/* Event Promotion Section */}
-      <section className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.2 }}
+        className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4"
+      >
         <h2 className="text-3xl font-semibold">PROJECT LONGSHOT Conference 2025</h2>
         <div className="text-2xl font-mono">
           <CountdownTimer targetDate="2025-06-01T00:00:00Z" />
@@ -21,21 +33,34 @@ export default function Home() {
           <input type="email" placeholder="Email address" className="flex-1 px-4 py-2 rounded border border-gray-300 dark:border-gray-700 bg-transparent" />
           <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Register Interest</button>
         </form>
-      </section>
+      </motion.section>
 
       {/* Institutional Credibility Section */}
-      <section id="about" className="py-16 px-6 text-center flex flex-col items-center gap-4">
+      <motion.section
+        id="about"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+        className="py-16 px-6 text-center flex flex-col items-center gap-4"
+      >
         <h2 className="text-3xl font-semibold">Backed by global leaders and top-tier academic institutions.</h2>
         <p className="max-w-3xl">PROJECT LONGSHOT is committed to advancing safe and aligned artificial intelligence. Our mission brings together policymakers, researchers, and industry to secure the future of AI.</p>
         <div className="h-20 w-full bg-gray-200 dark:bg-gray-800 flex items-center justify-center rounded">Logos Placeholder</div>
-      </section>
+      </motion.section>
 
       {/* Academic & Expert Engagement */}
-      <section className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4">
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, delay: 0.6 }}
+        className="bg-gray-100 dark:bg-gray-900 py-16 px-6 text-center flex flex-col items-center gap-4"
+      >
         <h2 className="text-3xl font-semibold">Join Leading Minds</h2>
         <p className="max-w-2xl">We welcome mathematicians, cognitive scientists, and machine learning researchers to collaborate with us on the toughest alignment challenges.</p>
         <Link href="#" className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-full">Apply to Collaborate</Link>
-      </section>
+      </motion.section>
 
       {/* Footer */}
       <footer className="mt-auto py-8 px-6 bg-gray-800 text-gray-200 flex flex-col items-center gap-4 text-sm">

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "next": "15.3.2",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{ts,tsx,js,jsx}"],
+  content: ["./app/**/*.{ts,tsx,js,jsx}", "./components/**/*.{ts,tsx,js,jsx}"],
+  darkMode: "class",
   theme: {
-    fontFamily: {
-      sans: ["Arial", "Helvetica", "sans-serif"],
-      mono: ["Menlo", "monospace"],
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", "var(--font-plex)", "sans-serif"],
+        mono: ["Menlo", "monospace"],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- configure Tailwind for font variables and dark mode via class
- switch global styles to dark theme by default
- load Inter and IBM Plex Sans via `next/font`
- animate landing and conference pages with `framer-motion`
- add `framer-motion` dependency

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*