### PR TITLE
Fix fonts and prerender error

### DIFF
--- a/app/conference/page.tsx
+++ b/app/conference/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { motion } from "framer-motion";
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,6 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-inter), var(--font-plex), sans-serif;
+  font-family: sans-serif;
   @apply antialiased;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, IBM_Plex_Sans } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-  display: "swap",
-});
-
-const plex = IBM_Plex_Sans({
-  subsets: ["latin"],
-  weight: ["400", "700"],
-  variable: "--font-plex",
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "PROJECT LONGSHOT",
@@ -26,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${plex.variable} dark`}>
+    <html lang="en" className="dark">
       <body>
         <header className="py-4 px-6 bg-gray-800 text-gray-200">
           <nav className="flex gap-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import CountdownTimer from "../components/CountdownTimer";
 import Link from "next/link";
 import { motion } from "framer-motion";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ["var(--font-inter)", "var(--font-plex)", "sans-serif"],
+        sans: ["sans-serif"],
         mono: ["Menlo", "monospace"],
       },
     },


### PR DESCRIPTION
## Summary
- remove Google font usage so build works offline
- adjust font families in CSS and Tailwind config
- mark pages that use framer-motion as client components

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*