### PR TITLE
Fix conference page rendering

### DIFF
--- a/app/conference/page.tsx
+++ b/app/conference/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { motion } from "framer-motion";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import CountdownTimer from "../components/CountdownTimer";
 import Link from "next/link";
 import { motion } from "framer-motion";


### PR DESCRIPTION
## Summary
- mark / and /conference pages as client components so `framer-motion` works during prerendering

## Testing
- `npm run build` *(fails: `next/font` can't fetch fonts in offline environment)*