### PR TITLE
Fix hero sections and add project branding

### DIFF
--- a/app/conference/page.tsx
+++ b/app/conference/page.tsx
@@ -11,9 +11,10 @@ export default function ConferencePage() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-950 via-gray-900 to-gray-800"
+        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-900 via-gray-800 to-gray-700"
       >
-        <h1 className="text-4xl sm:text-6xl font-bold tracking-tight">PROJECT LONGSHOT 2025 Conference</h1>
+        <img src="/logo.svg" alt="Project LONGSHOT logo" className="h-16 w-auto" />
+        <h1 className="text-4xl sm:text-6xl font-bold tracking-tight text-white">PROJECT LONGSHOT 2025 Conference</h1>
         <p className="text-lg sm:text-xl max-w-2xl">Shaping global policy and science for safe AI</p>
         <p className="text-md font-mono">Mid-2025 (exact dates soon)</p>
         <form className="mt-6 flex flex-col sm:flex-row gap-2 w-full max-w-md">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,14 +29,15 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} ${plex.variable} dark`}>
       <body>
         <header className="py-4 px-6 bg-gray-800 text-gray-200">
-          <nav className="flex gap-4">
-            <a href="/" className="hover:underline">
-              Home
+          <div className="flex items-center justify-between">
+            <a href="/" aria-label="Home">
+              <img src="/logo.svg" alt="Project LONGSHOT logo" className="h-8 w-auto" />
             </a>
-            <a href="/conference" className="hover:underline">
-              Conference
-            </a>
-          </nav>
+            <nav className="flex gap-4">
+              <a href="/" className="hover:underline">Home</a>
+              <a href="/conference" className="hover:underline">Conference</a>
+            </nav>
+          </div>
         </header>
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,9 +12,10 @@ export default function Home() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
-        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-950 via-gray-900 to-gray-800"
+        className="flex flex-col justify-center items-center text-center py-24 px-6 sm:py-32 gap-6 bg-gradient-to-b from-gray-900 via-gray-800 to-gray-700"
       >
-        <h1 className="text-4xl sm:text-6xl font-bold tracking-tight">Aligning AI. Securing the Future.</h1>
+        <img src="/logo.svg" alt="Project LONGSHOT logo" className="h-16 w-auto" />
+        <h1 className="text-4xl sm:text-6xl font-bold tracking-tight text-white">Aligning AI. Securing the Future.</h1>
         <p className="text-lg sm:text-xl max-w-2xl">Join world-leading experts and policymakers at the forefront of AI alignment.</p>
         <Link href="#about" className="mt-6 inline-block bg-blue-600 hover:bg-blue-700 text-white rounded-full px-6 py-3">Learn More About PROJECT LONGSHOT</Link>
       </motion.section>
@@ -49,6 +50,12 @@ export default function Home() {
         <h2 className="text-3xl font-semibold">Backed by global leaders and top-tier academic institutions.</h2>
         <p className="max-w-3xl">PROJECT LONGSHOT is committed to advancing safe and aligned artificial intelligence. Our mission brings together policymakers, researchers, and industry to secure the future of AI.</p>
         <div className="h-20 w-full bg-gray-200 dark:bg-gray-800 flex items-center justify-center rounded">Logos Placeholder</div>
+        <div className="flex flex-wrap justify-center gap-6 py-4">
+          <img src="/logo.svg" alt="Project LONGSHOT" className="h-12 w-auto" />
+          <img src="/globe.svg" alt="Partner logo" className="h-12 w-auto invert" />
+          <img src="/file.svg" alt="Partner logo" className="h-12 w-auto invert" />
+          <img src="/window.svg" alt="Partner logo" className="h-12 w-auto invert" />
+        </div>
       </motion.section>
 
       {/* Academic & Expert Engagement */}

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50" fill="none">
+  <rect width="200" height="50" fill="#0a0a0a"/>
+  <text x="100" y="30" font-size="24" fill="white" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">LONGSHOT</text>
+</svg>


### PR DESCRIPTION
## Summary
- show project logo in layout header
- improve gradients and add logos on the main page
- tweak conference page hero
- add simple LONGSHOT logo asset

## Testing
- `npm run lint` *(fails: Next.js prompts for configuration)*
- `npm run build` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*